### PR TITLE
Fix incorrect handling of url=undefined by History.push/replaceState()

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/History.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/javascript/host/History.java
@@ -127,13 +127,13 @@ public class History extends HtmlUnitScriptable {
      * @param url an optional URL
      */
     @JsxFunction
-    public void replaceState(final Object object, final String title, final String url) {
+    public void replaceState(final Object object, final String title, final Object url) {
         final WebWindow w = getWindow().getWebWindow();
         try {
             URL newStateUrl = null;
-            final HtmlPage page = (HtmlPage) w.getEnclosedPage();
-            if (StringUtils.isNotBlank(url)) {
-                newStateUrl = page.getFullyQualifiedUrl(url);
+            if (url instanceof String && StringUtils.isNotBlank((String) url)) {
+                final HtmlPage page = (HtmlPage) w.getEnclosedPage();
+                newStateUrl = page.getFullyQualifiedUrl((String) url);
             }
             w.getHistory().replaceState(object, newStateUrl);
         }
@@ -149,13 +149,13 @@ public class History extends HtmlUnitScriptable {
      * @param url an optional URL
      */
     @JsxFunction
-    public void pushState(final Object object, final String title, final String url) {
+    public void pushState(final Object object, final String title, final Object url) {
         final WebWindow w = getWindow().getWebWindow();
         try {
             URL newStateUrl = null;
-            final HtmlPage page = (HtmlPage) w.getEnclosedPage();
-            if (StringUtils.isNotBlank(url)) {
-                newStateUrl = page.getFullyQualifiedUrl(url);
+            if (url instanceof String && StringUtils.isNotBlank((String) url)) {
+                final HtmlPage page = (HtmlPage) w.getEnclosedPage();
+                newStateUrl = page.getFullyQualifiedUrl((String) url);
             }
             w.getHistory().pushState(object, newStateUrl);
         }

--- a/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/History2Test.java
+++ b/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/History2Test.java
@@ -603,6 +603,90 @@ public class History2Test extends WebDriverTestCase {
         loadPageVerifyTitle2(html);
     }
 
+    @Test
+    @Alerts({"href=§§URL§§", "href=§§URL§§"})
+    public void replaceStateUndefinedObj() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log('href=' + location.href);\n"
+                + "    window.history.replaceState(null, '', undefined);\n"
+                + "    log('href=' + location.href);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts({"href=§§URL§§", "href=§§URL§§undefined"})
+    public void replaceStateUndefinedString() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log('href=' + location.href);\n"
+                + "    window.history.replaceState(null, '', 'undefined');\n"
+                + "    log('href=' + location.href);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts({"href=§§URL§§", "href=§§URL§§"})
+    public void pushStateUndefinedObj() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log('href=' + location.href);\n"
+                + "    window.history.pushState(null, '', undefined);\n"
+                + "    log('href=' + location.href);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
+    @Test
+    @Alerts({"href=§§URL§§", "href=§§URL§§undefined"})
+    public void pushStateUndefinedString() throws Exception {
+        final String html = "<html>\n"
+                + "<head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log('href=' + location.href);\n"
+                + "    window.history.pushState(null, '', 'undefined');\n"
+                + "    log('href=' + location.href);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head>\n"
+                + "<body onload='test()'>\n"
+                + "</body></html>";
+
+        expandExpectedAlertsVariables(URL_FIRST);
+        loadPageVerifyTitle2(html);
+    }
+
     /**
      * @throws Exception if an error occurs
      */


### PR DESCRIPTION
# Overview

This PR fixes the incorrect behaviour of `History.replaceState()` and `History.pushState()` when `undefined` is passed for the `url` parameter.

These two methods treated `undefined` and therefore the url as the string `'undefined'`, and set the `location.href` to a file of that name, when it should instead be ignoring this parameter.

# Tests to reproduce the issue

Below code shows behaviors of HtmlUnit's `history.replaceState()` and expected (e.g. Chrome).

```html
<!DOCTYPE html>
<html>
<head>
<script>

// Assuming location.href is "https://www.example.com/"
history.replaceState(null, '', undefined);

// Expected: "https://www.example.com/"
// HtmlUnit: "https://www.example.com/undefined"
console.log(location.href);

</script>
</head>
<body>
</body>
</html>
```