### PR TITLE
Implement Cache-Control: no-cache directive

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/HttpHeader.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/HttpHeader.java
@@ -19,6 +19,7 @@ package com.gargoylesoftware.htmlunit;
  *
  * @author Ronald Brill
  * @author Anton Demydenko
+ * @author Lai Quang Duong
  */
 public final class HttpHeader {
 
@@ -37,6 +38,15 @@ public final class HttpHeader {
 
     /** Last-Modified. */
     public static final String LAST_MODIFIED = "Last-Modified";
+
+    /** Etag. */
+    public static final String ETAG = "Etag";
+
+    /** If-None-Match. */
+    public static final String IF_NONE_MATCH = "If-None-Match";
+
+    /** If-Modified-Since. */
+    public static final String IF_MODIFIED_SINCE = "If-Modified-Since";
 
     /** Expires. */
     public static final String EXPIRES = "Expires";

--- a/src/main/java/com/gargoylesoftware/htmlunit/WebResponseFromCache.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/WebResponseFromCache.java
@@ -14,6 +14,10 @@
  */
 package com.gargoylesoftware.htmlunit;
 
+import java.util.Collections;
+import java.util.List;
+
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.gargoylesoftware.htmlunit.util.WebResponseWrapper;
 
 /**
@@ -25,15 +29,29 @@ import com.gargoylesoftware.htmlunit.util.WebResponseWrapper;
 class WebResponseFromCache extends WebResponseWrapper {
 
     private final WebRequest request_;
+    private final List<NameValuePair> responseHeaders_;
 
     /**
-     * Wraps the provide response for the given request
+     * Wraps the provided cached response for a new request.
+     * @param cachedResponse the response from cache
+     * @param overwriteHeaders list of headers to overwrite cachedResponse headers
+     * @param currentRequest the new request
+     */
+    WebResponseFromCache(final WebResponse cachedResponse, final List<NameValuePair> overwriteHeaders, final WebRequest currentRequest) {
+        super(cachedResponse);
+        request_ = currentRequest;
+        responseHeaders_ = Collections.unmodifiableList(overwriteHeaders);
+    }
+
+    /**
+     * Wraps the provided response for the given request
      * @param cachedResponse the response from cache
      * @param currentRequest the new request
      */
     WebResponseFromCache(final WebResponse cachedResponse, final WebRequest currentRequest) {
         super(cachedResponse);
         request_ = currentRequest;
+        responseHeaders_ = null;
     }
 
     /**
@@ -42,5 +60,30 @@ class WebResponseFromCache extends WebResponseWrapper {
     @Override
     public WebRequest getWebRequest() {
         return request_;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<NameValuePair> getResponseHeaders() {
+        return responseHeaders_ != null ? responseHeaders_ : super.getResponseHeaders();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getResponseHeaderValue(final String headerName) {
+        if (responseHeaders_ == null) {
+            return super.getResponseHeaderValue(headerName);
+        }
+
+        for (final NameValuePair pair : responseHeaders_) {
+            if (pair.getName().equalsIgnoreCase(headerName)) {
+                return pair.getValue();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/gargoylesoftware/htmlunit/util/HeaderUtils.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/util/HeaderUtils.java
@@ -24,6 +24,7 @@ import com.gargoylesoftware.htmlunit.WebResponse;
 
 /**
  * @author Anton Demydenko
+ * @author Lai Quang Duong
  */
 public final class HeaderUtils {
 
@@ -70,6 +71,22 @@ public final class HeaderUtils {
      */
     public static boolean containsNoCache(final WebResponse response) {
         return containsCacheControlValue(response, CACHE_CONTROL_NO_CACHE);
+    }
+
+    /**
+     * @param response {@code WebResponse}
+     * @return if 'Etag' header is present
+     */
+    public static boolean containsETag(final WebResponse response) {
+        return response.getResponseHeaderValue(HttpHeader.ETAG) != null;
+    }
+
+    /**
+     * @param response {@code WebResponse}
+     * @return if 'Last-Modified' header is present
+     */
+    public static boolean containsLastModified(final WebResponse response) {
+        return response.getResponseHeaderValue(HttpHeader.LAST_MODIFIED) != null;
     }
 
     /**


### PR DESCRIPTION
# Overview

This PR add the missing handling of `Cache-Control: no-cache` header based on [rfc 9111 specification](https://www.rfc-editor.org/rfc/rfc9111#name-validation).