### PR TITLE
Remove cookies from preflight and cross-origin requests

### DIFF
--- a/src/main/java/com/gargoylesoftware/htmlunit/HttpWebConnection.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/HttpWebConnection.java
@@ -697,6 +697,11 @@ public class HttpWebConnection implements WebConnection {
                 new RequestExpectContinue());
         b.add(new RequestAcceptEncoding());
         b.add(new RequestAuthCache());
+
+        if (!webRequest.hasHint(HttpHint.BlockCookies)) {
+            b.add(new ResponseProcessCookies());
+        }
+
         b.add(new ResponseProcessCookies());
         builder.setHttpProcessor(b.build());
     }
@@ -913,7 +918,9 @@ public class HttpWebConnection implements WebConnection {
                 list.add(new RequestClientConnControl());
             }
             else if (HttpHeader.COOKIE.equals(header)) {
-                list.add(new RequestAddCookies());
+                if(!webRequest.hasHint(HttpHint.BlockCookies)) {
+                    list.add(new RequestAddCookies());
+                }
             }
             else if (HttpHeader.DNT.equals(header) && webClient_.getOptions().isDoNotTrackEnabled()) {
                 list.add(new DntHeaderHttpRequestInterceptor("1"));

--- a/src/main/java/com/gargoylesoftware/htmlunit/WebRequest.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/WebRequest.java
@@ -173,6 +173,17 @@ public class WebRequest implements Serializable {
                 throw new RuntimeException("Cannot change hostname of URL: " + url.toExternalForm(), e);
             }
         }
+
+        if (("https".equals(url.getProtocol()) && url.getPort() == 443)
+                || ("http".equals(url.getProtocol()) && url.getPort() == 80)) {
+            try {
+                url = UrlUtils.getUrlWithNewPort(url, -1);
+            }
+            catch (final MalformedURLException e) {
+                throw new RuntimeException("Cannot strip default port of URL: " + url.toExternalForm(), e);
+            }
+        }
+
         url_ = url.toExternalForm();
 
         // http://john.smith:secret@localhost

--- a/src/main/java/com/gargoylesoftware/htmlunit/WebRequest.java
+++ b/src/main/java/com/gargoylesoftware/htmlunit/WebRequest.java
@@ -57,7 +57,9 @@ public class WebRequest implements Serializable {
 
     public enum HttpHint {
         /** Force to include the charset. */
-        IncludeCharsetInContentTypeHeader
+        IncludeCharsetInContentTypeHeader,
+        /** Disable sending of stored cookies and receiving of new cookies. */
+        BlockCookies
     }
 
     private static final Pattern DOT_PATTERN = Pattern.compile("/\\./");


### PR DESCRIPTION
This PR does the following:
* Add code to `WebRequest.setUrl()` to strip default ports from request urls such as 80 for `http://`
* Fix to prevent sending cookies with preflight and cross-origin requests as specified by [wc3 specification](https://www.w3.org/TR/2020/SPSD-cors-20200602/)