### PR TITLE
RegExpJsToJavaConverter: Char ranges following [] or [^] are broken

### DIFF
--- a/src/main/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverter.java
+++ b/src/main/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverter.java
@@ -241,7 +241,7 @@ public class RegExpJsToJavaConverter {
                 else if (']' == next) {
                     // [^]
                     tape_.move(-3);
-                    tape_.replace(3, "[\\s\\S]");
+                    tape_.replace(3, "(?s:.)");
                 }
                 else {
                     tape_.move(-1);

--- a/src/main/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverter.java
+++ b/src/main/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverter.java
@@ -242,6 +242,7 @@ public class RegExpJsToJavaConverter {
                     // [^]
                     tape_.move(-3);
                     tape_.replace(3, "(?s:.)");
+                    insideCharClass_ = false;
                 }
                 else {
                     tape_.move(-1);
@@ -251,6 +252,7 @@ public class RegExpJsToJavaConverter {
                 // []
                 tape_.move(-2);
                 tape_.replace(2, "(?!)");
+                insideCharClass_ = false;
             }
             else {
                 tape_.move(-1);

--- a/src/test/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverterTest.java
+++ b/src/test/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverterTest.java
@@ -191,9 +191,10 @@ public class RegExpJsToJavaConverterTest {
     public void charClassOpenInside() {
         final RegExpJsToJavaConverter regExpJsToJavaConverter = new RegExpJsToJavaConverter();
 
-        final String in = "[af[g]";
-        final String out = regExpJsToJavaConverter.convert(in);
-        assertEquals("[af\\[g]", out);
+        assertEquals("[af\\[g]", regExpJsToJavaConverter.convert("[af[g]"));
+        assertEquals("(?!)[a][b]", HtmlUnitRegExpProxy.jsRegExpToJavaRegExp("[][a][b]"));
+        assertEquals("[a](?s:.)[b]", HtmlUnitRegExpProxy.jsRegExpToJavaRegExp("[a][^][b]"));
+        assertEquals("[a\\[b]c]", HtmlUnitRegExpProxy.jsRegExpToJavaRegExp("[a[b]c]"));
     }
 
     /**


### PR DESCRIPTION
This PR does the following:
- Fix issue where char ranges following `[]` or `[^]` are broken
    - e.g. `[]a[b]` becomes `(?!)a\[b]` (strange back-slash added by [this](https://github.com/HtmlUnit/htmlunit/blob/4e2de56e7e541a4d8233ed15bbbcef49f7bf02be/src/main/java/org/htmlunit/javascript/regexp/RegExpJsToJavaConverter.java#L208) instead of the expected `(?!)a[b]`
    - This issue is caused by `processCharClassStart()` failing to reset `insideCharClass_` after the end bracket `]` has been processed for `[]` and `[^]`. 
    
- Use `(?s:.)` for `[^]` instead of `[\s\S]` because latter has poor performance.
