### PR TITLE
Reflect: Implement Reflect.ownKeys()

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/Reflect.java
+++ b/src/main/java/org/htmlunit/javascript/host/Reflect.java
@@ -19,12 +19,18 @@ import static org.htmlunit.javascript.configuration.SupportedBrowser.EDGE;
 import static org.htmlunit.javascript.configuration.SupportedBrowser.FF;
 import static org.htmlunit.javascript.configuration.SupportedBrowser.FF_ESR;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.htmlunit.corejs.javascript.Context;
 import org.htmlunit.corejs.javascript.FunctionObject;
+import org.htmlunit.corejs.javascript.ScriptRuntime;
 import org.htmlunit.corejs.javascript.Scriptable;
 import org.htmlunit.corejs.javascript.ScriptableObject;
+import org.htmlunit.corejs.javascript.Symbol;
 import org.htmlunit.javascript.HtmlUnitScriptable;
 import org.htmlunit.javascript.configuration.JsxClass;
+import org.htmlunit.javascript.configuration.JsxStaticFunction;
 
 /**
  * A JavaScript object for {@code Reflect}.
@@ -41,9 +47,13 @@ public class Reflect extends HtmlUnitScriptable {
      */
     public Reflect() {
         try {
-            final FunctionObject functionObject = new FunctionObject("has",
+            final FunctionObject hasFunctionObject = new FunctionObject("has",
                     getClass().getDeclaredMethod("has", Scriptable.class, String.class), this);
-            defineProperty("has", functionObject, ScriptableObject.DONTENUM);
+            defineProperty("has", hasFunctionObject, ScriptableObject.DONTENUM);
+
+            final FunctionObject ownKeysFunctionObject = new FunctionObject("ownKeys",
+                    getClass().getDeclaredMethod("ownKeys", Scriptable.class), this);
+            defineProperty("ownKeys", ownKeysFunctionObject, ScriptableObject.DONTENUM);
         }
         catch (final Exception e) {
             Context.throwAsScriptRuntimeEx(e);
@@ -59,5 +69,30 @@ public class Reflect extends HtmlUnitScriptable {
      */
     public boolean has(final Scriptable target, final String propertyKey) {
         return ScriptableObject.hasProperty(target, propertyKey);
+    }
+
+    /**
+     * Implements the ownKeys() static method as documented in docs.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys
+     */
+    @JsxStaticFunction
+    public Scriptable ownKeys(final Scriptable target) {
+        final ScriptableObject obj = ensureScriptableObject(target);
+        final List<Object> strings = new ArrayList<>();
+        final List<Object> symbols = new ArrayList<>();
+
+        for (Object o : obj.getAllIdsIncludingSymbols()) {
+            if (o instanceof Symbol) {
+                symbols.add(o);
+            } else {
+                strings.add(ScriptRuntime.toString(o));
+            }
+        }
+
+        Object[] keys = new Object[strings.size() + symbols.size()];
+        System.arraycopy(strings.toArray(), 0, keys, 0, strings.size());
+        System.arraycopy(symbols.toArray(), 0, keys, strings.size(), symbols.size());
+
+        return Context.getCurrentContext().newArray(this, keys);
     }
 }

--- a/src/test/java/org/htmlunit/javascript/host/ReflectTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/ReflectTest.java
@@ -52,4 +52,35 @@ public class ReflectTest extends WebDriverTestCase {
 
         loadPageVerifyTitle2(html);
     }
+
+    /**
+     * @throws Exception if the test fails
+     */
+    @Test
+    @Alerts(DEFAULT = {"-1,0,6,8,55,773,str,str2,Symbol(foo),Symbol(bar)"},
+            IE = "no Reflect")
+    public void ownKeys() throws Exception {
+        final String html = "<html><head>\n"
+                + "<body>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  if (typeof Reflect != 'undefined') {\n"
+                + "    var obj = {};\n"
+                + "    obj[Symbol.for('foo')] = 0;\n"
+                + "    obj['str'] = 0;\n"
+                + "    obj[773] = 0;\n"
+                + "    obj['55'] = 0;\n"
+                + "    obj[0] = 0;\n"
+                + "    obj['-1'] = 0;\n"
+                + "    obj[8] = 0;\n"
+                + "    obj['6'] = 0;\n"
+                + "    obj[Symbol.for('bar')] = 0;\n"
+                + "    obj['str2'] = 0;\n"
+                + "    log(Reflect.ownKeys(obj));\n"
+                + "  } else { log('no Reflect'); }\n"
+                + "</script>\n"
+                + "</body></html>";
+
+        loadPageVerifyTitle2(html);
+    }
 }


### PR DESCRIPTION
# Overview

This PR does the following:
- Proposes an implementation for [`Reflect.ownKeys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys)
- **WARNING:** **DO NOT MERGE**. **DOES NOT COMPILE**. See following point.
- For this implementation to compile, [Rhino's `ScriptableObject.java`](https://github.com/HtmlUnit/htmlunit-rhino-fork/blob/b019aa8b2a49446426042da15413840ecb4edc7b/src/org/mozilla/javascript/ScriptableObject.java#L49) needs a new method (e.g. `getAllIdsIncludingSymbols()`) that allows retrieval of all properties (enumerable or not not) including both strings and symbols:

    ```java
    public Object[] getAllIdsIncludingSymbols() {
        return getIds(true, true);
    }
    ```

# Test case

(This test case is also implemented in `ReflectTest.java`.)

```js
var obj = {
  [Symbol.for('foo')]: 0,
  "str": 0,
  773: 0,
  "55": 0,
  0: 0,
  "-1": 0,
  8: 0,
  "6": 8,
  [Symbol.for('bar')]: 0,
  "str2": 0,
};

// Chrome:  [ "0", "6", "8", "55", "773", "str", "-1", "str2", Symbol("foo"), Symbol("bar") ]
// HtmlUnit: [ "-1", "0", "6", "8", "55", "773", "str", "str2", "Symbol(foo)", "Symbol(bar)" ]
console.log(Reflect.ownKeys(obj));
```

# Points of note

## About the javadoc

The javadoc for `ownKeys()` is very basic because:
- We aren't sure if licensing allows us to copy mdn docs' words or whether we need to reword to our own words
- Perhaps writing fully descriptive API docs in the javadoc of these methods is not all that useful since they're JS methods, and a basic javadoc is easier to produce

## Regarding the ordering of property keys returned

Notice `-1` is in the wrong place.:

* Chrome:  `[ "0", "6", "8", "55", "773", "str", "-1", "str2", Symbol("foo"), Symbol("bar") ]`
* HtmlUnit: `[ "-1", "0", "6", "8", "55", "773", "str", "str2", "Symbol(foo)", "Symbol(bar)" ]`

The [specs for `Reflect.ownKeys()` provide clear description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys#return_value) for the ordering of these:

> 1. Non-negative integer indexes in increasing numeric order (but as strings)
> 2. Other string keys in the order of property creation
> 3. Symbol keys in the order of property creation.

We cannot accommodate this for `-1` and other negative integers because Rhino does not preserve the property creation order of negative integer keys.  This appears to be a bug in Rhino:

* Rhino DOES preserve the property creation order of non-integer keys adhering to specs
* Rhino DOES orders "positive integer" keys in canonical order adhering to specs
* Rhino DOES NOT preserve the property creation order of "negative integer" since it seems to be incorrectly treating these as an _integer index_ even though they're not in the defined range of `0 <= i <= F` [1]

[1] https://262.ecma-international.org/13.0/#sec-object-type

## Regarding the initialization of the test case

> ```js
> var obj = {
>   [Symbol.for('foo')]: 0,
>   "str": 0,
>   773: 0,
>   ...
> };


HtmlUnit throws `invalid property id` error on the `[Symbol.for('foo')]` part which is a [computed property name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names). The object is instead initialized in `ReflectTest.java` as such:

```js
var obj = {};
obj[Symbol.for('foo')] = 0;
obj['str'] = 0;
obj[773] = 0;
obj["55"] = 0;
obj[0] = 0;
obj['-1'] = 0;
obj[8] = 0;
obj["6"] = 0;
obj[Symbol.for('bar')] = 0;
obj['str2'] = 0;
```

