### PR TITLE
Reflect: Fix regression with prototype of .has

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/Reflect.java
+++ b/src/main/java/org/htmlunit/javascript/host/Reflect.java
@@ -37,9 +37,12 @@ import org.htmlunit.javascript.configuration.JsxClass;
 public class Reflect extends HtmlUnitScriptable {
 
     /**
-     * Creates an instance.
+     * {@inheritedDoc}
      */
-    public Reflect() {
+    @Override
+    public void setParentScope(final Scriptable scope) {
+        super.setParentScope(scope);
+
         try {
             final FunctionObject functionObject = new FunctionObject("has",
                     getClass().getDeclaredMethod("has", Scriptable.class, String.class), this);

--- a/src/test/java/org/htmlunit/javascript/host/ReflectTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/ReflectTest.java
@@ -33,7 +33,7 @@ public class ReflectTest extends WebDriverTestCase {
      * @throws Exception if the test fails
      */
     @Test
-    @Alerts(DEFAULT = {"true", "false", "true", "true"},
+    @Alerts(DEFAULT = {"function () { [native code] }", "true", "false", "true", "true"},
             IE = "no Reflect")
     public void has() throws Exception {
         final String html = "<html><head>\n"
@@ -41,6 +41,8 @@ public class ReflectTest extends WebDriverTestCase {
             + "<script>\n"
             + LOG_TITLE_FUNCTION
             + "  if (typeof Reflect != 'undefined') {\n"
+            + "    log(Reflect.has.__proto__);\n"
+
             + "    log(Reflect.has({x: 0}, 'x'));\n"
             + "    log(Reflect.has({x: 0}, 'y'));\n"
             + "    log(Reflect.has({x: 0}, 'toString'));\n"


### PR DESCRIPTION
This PR does the following:
- Fix a regression where the prototype of `Reflect.has` is null, was caused by my previous [PR](https://github.com/duonglaiquang/htmlunit/pull/9) [1]

[1] Moving the property initialization from `setParentScope()` to the constructor broke initialization of new `FunctionObject` instances because the prototype is pulled from the parent scope.
