### PR TITLE
Refactor WebResponse charset handling

### DIFF
--- a/src/main/java/org/htmlunit/WebRequest.java
+++ b/src/main/java/org/htmlunit/WebRequest.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -79,6 +80,7 @@ public class WebRequest implements Serializable {
     private Credentials credentials_;
     private int timeout_;
     private transient Charset charset_ = ISO_8859_1;
+    private transient Charset defaultResponseContentCharset_ = ISO_8859_1;
     private transient Set<HttpHint> httpHints_;
 
     /* These two are mutually exclusive; additionally, requestBody_ should only be set for POST requests. */
@@ -603,6 +605,23 @@ public class WebRequest implements Serializable {
      */
     public void setCharset(final Charset charset) {
         charset_ = charset;
+    }
+
+    /**
+     * Returns the default character set to use for the response when it does not specify one.
+     */
+    public Charset getDefaultResponseContentCharset() {
+        return defaultResponseContentCharset_;
+    }
+
+    /**
+     * Sets the default character set to use for the response when it does not specify one.
+     * <p>
+     * Unless set, the default is {@link java.nio.charset.StandardCharsets#ISO_8859_1}.
+     * @param defaultResponseContentCharset the default character set of the response
+     */
+    public void setDefaultResponseContentCharset(final Charset defaultResponseContentCharset) {
+        this.defaultResponseContentCharset_ = Objects.requireNonNull(defaultResponseContentCharset);
     }
 
     public boolean hasHint(final HttpHint hint) {

--- a/src/main/java/org/htmlunit/WebRequest.java
+++ b/src/main/java/org/htmlunit/WebRequest.java
@@ -15,6 +15,7 @@
 package org.htmlunit;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -80,7 +81,7 @@ public class WebRequest implements Serializable {
     private Credentials credentials_;
     private int timeout_;
     private transient Charset charset_ = ISO_8859_1;
-    private transient Charset defaultResponseContentCharset_ = ISO_8859_1;
+    private transient Charset defaultResponseContentCharset_ = UTF_8; // https://datatracker.ietf.org/doc/html/rfc6838#section-4.2.1
     private transient Set<HttpHint> httpHints_;
 
     /* These two are mutually exclusive; additionally, requestBody_ should only be set for POST requests. */
@@ -617,7 +618,7 @@ public class WebRequest implements Serializable {
     /**
      * Sets the default character set to use for the response when it does not specify one.
      * <p>
-     * Unless set, the default is {@link java.nio.charset.StandardCharsets#ISO_8859_1}.
+     * Unless set, the default is {@link java.nio.charset.StandardCharsets#UTF_8}.
      * @param defaultResponseContentCharset the default character set of the response
      */
     public void setDefaultResponseContentCharset(final Charset defaultResponseContentCharset) {

--- a/src/main/java/org/htmlunit/WebResponse.java
+++ b/src/main/java/org/htmlunit/WebResponse.java
@@ -30,7 +30,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.htmlunit.DefaultPageCreator.PageType;
 import org.htmlunit.httpclient.HttpClientConverter;
 import org.htmlunit.util.EncodingSniffer;
 import org.htmlunit.util.NameValuePair;
@@ -204,9 +203,7 @@ public class WebResponse implements Serializable {
      * Returns the content charset for this response, even if no charset was specified explicitly.
      * This method always returns a valid charset. This method first checks the {@code Content-Type}
      * header; if not found, it checks the request charset; as a last resort, this method
-     * returns {@link java.nio.charset.StandardCharsets#ISO_8859_1}.
-     * If no charset is defined for an xml response, then UTF-8 is used
-     * @see <a href="http://www.w3.org/TR/xml/#charencoding">Character Encoding</a>
+     * returns {@link java.nio.charset.StandardCharsets#UTF_8}.
      * @return the content charset for this response
      */
     public Charset getContentCharset() {
@@ -214,14 +211,6 @@ public class WebResponse implements Serializable {
         if (charset != null) {
             return charset;
         }
-
-        final String contentType = getContentType();
-
-        // xml pages are using a different content type
-        if (PageType.XML == DefaultPageCreator.determinePageType(contentType)) {
-            return UTF_8;
-        }
-
         return getWebRequest().getDefaultResponseContentCharset();
     }
 

--- a/src/main/java/org/htmlunit/WebResponse.java
+++ b/src/main/java/org/htmlunit/WebResponse.java
@@ -14,7 +14,6 @@
  */
 package org.htmlunit;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_16BE;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -92,7 +91,6 @@ public class WebResponse implements Serializable {
     private final long loadTime_;
     private final WebResponseData responseData_;
     private final WebRequest request_;
-    private boolean defaultCharsetUtf8_;
     private boolean wasBlocked_;
     private String blockReason_;
 
@@ -213,21 +211,18 @@ public class WebResponse implements Serializable {
      */
     public Charset getContentCharset() {
         Charset charset = getContentCharsetOrNull();
-        if (charset == null) {
-            final String contentType = getContentType();
-
-            // xml pages are using a different content type
-            if (null != contentType
-                && (defaultCharsetUtf8_
-                    || PageType.XML == DefaultPageCreator.determinePageType(contentType))) {
-                return UTF_8;
-            }
+        if (charset != null) {
+            return charset;
         }
 
-        if (charset == null) {
-            charset = ISO_8859_1;
+        final String contentType = getContentType();
+
+        // xml pages are using a different content type
+        if (PageType.XML == DefaultPageCreator.determinePageType(contentType)) {
+            return UTF_8;
         }
-        return charset;
+
+        return getWebRequest().getDefaultResponseContentCharset();
     }
 
     /**
@@ -343,9 +338,11 @@ public class WebResponse implements Serializable {
 
     /**
      * Mark this response for using UTF-8 as default charset.
+     * @deprecated Use WebRequest.setDefaultResponseContentCharset(Charset)
      */
+    @Deprecated
     public void defaultCharsetUtf8() {
-        defaultCharsetUtf8_ = true;
+        getWebRequest().setDefaultResponseContentCharset(UTF_8);
     }
 
     /**

--- a/src/main/java/org/htmlunit/html/BaseFrameElement.java
+++ b/src/main/java/org/htmlunit/html/BaseFrameElement.java
@@ -189,12 +189,22 @@ public abstract class BaseFrameElement extends HtmlElement {
                 return;
             }
 
-            final WebRequest request = new WebRequest(url, page.getCharset(), page.getUrl());
+            final Charset pageCharset = page.getCharset();
+            final URL pageUrl = page.getUrl();
+            final WebRequest request = new WebRequest(url, pageCharset, pageUrl);
 
             if (isAlreadyLoadedByAncestor(url, request.getCharset())) {
                 notifyIncorrectness("Recursive src attribute of " + getTagName() + ": url=[" + source + "]. Ignored.");
                 return;
             }
+
+            // Use parent document's charset as container charset if same origin
+            // https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding
+            if (pageUrl.getProtocol().equals(url.getProtocol())
+                    && pageUrl.getAuthority().equals(url.getAuthority())) {
+                request.setDefaultResponseContentCharset(pageCharset);
+            }
+
             try {
                 webClient.getPage(enclosedWindow_, request);
             }

--- a/src/main/java/org/htmlunit/html/parser/neko/HtmlUnitNekoHtmlParser.java
+++ b/src/main/java/org/htmlunit/html/parser/neko/HtmlUnitNekoHtmlParser.java
@@ -20,7 +20,6 @@ import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -173,12 +172,10 @@ public final class HtmlUnitNekoHtmlParser implements HTMLParser {
         final HtmlUnitNekoDOMBuilder domBuilder =
                 new HtmlUnitNekoDOMBuilder(this, page, url, null, createdByJavascript);
 
-        Charset charset = webResponse.getContentCharsetOrNull();
+        Charset charset = webResponse.getContentCharset();
         try {
-            if (charset == null) {
-                charset = StandardCharsets.ISO_8859_1;
-            }
-            else {
+            if (!webResponse.wasContentCharsetTentative()) {
+                // The charset is certain so ignore any others found in the document
                 domBuilder.setFeature(HTMLScanner.IGNORE_SPECIFIED_CHARSET, true);
             }
 

--- a/src/main/java/org/htmlunit/javascript/host/dom/Document.java
+++ b/src/main/java/org/htmlunit/javascript/host/dom/Document.java
@@ -29,7 +29,6 @@ import static org.htmlunit.javascript.configuration.SupportedBrowser.FF_ESR;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -122,7 +121,6 @@ import org.htmlunit.javascript.host.html.HTMLBodyElement;
 import org.htmlunit.javascript.host.html.HTMLCollection;
 import org.htmlunit.javascript.host.html.HTMLElement;
 import org.htmlunit.javascript.host.html.HTMLFrameSetElement;
-import org.htmlunit.util.EncodingSniffer;
 import org.htmlunit.util.UrlUtils;
 import org.htmlunit.xpath.xml.utils.PrefixResolver;
 import org.w3c.dom.CDATASection;
@@ -753,8 +751,7 @@ public class Document extends Node {
             // TODO: implement XmlPage.getCharset
             return "";
         }
-        final Charset charset = getPage().getCharset();
-        return EncodingSniffer.translateEncodingLabel(charset);
+        return getPage().getCharset().name();
     }
 
     /**
@@ -767,8 +764,7 @@ public class Document extends Node {
             // TODO: implement XmlPage.getCharset
             return "";
         }
-        final Charset charset = getPage().getCharset();
-        return EncodingSniffer.translateEncodingLabel(charset);
+        return getPage().getCharset().name();
     }
 
     /**
@@ -1841,8 +1837,7 @@ public class Document extends Node {
      */
     @JsxGetter
     public String getInputEncoding() {
-        final Charset encoding = getPage().getCharset();
-        return EncodingSniffer.translateEncodingLabel(encoding);
+        return getPage().getCharset().name();
     }
 
     /**

--- a/src/main/java/org/htmlunit/javascript/host/xml/XMLHttpRequest.java
+++ b/src/main/java/org/htmlunit/javascript/host/xml/XMLHttpRequest.java
@@ -668,6 +668,8 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
             final WebRequest request = new WebRequest(fullUrl, getBrowserVersion().getXmlHttpRequestAcceptHeader(),
                                                                 getBrowserVersion().getAcceptEncodingHeader());
             request.setCharset(UTF_8);
+            // https://xhr.spec.whatwg.org/#response-body
+            request.setDefaultResponseContentCharset(UTF_8);
             request.setRefererlHeader(containingPage.getUrl());
 
             try {
@@ -962,8 +964,6 @@ public class XMLHttpRequest extends XMLHttpRequestEventTarget {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Web response loaded successfully.");
             }
-            // this kind of web responses using UTF-8 as default encoding
-            webResponse_.defaultCharsetUtf8();
 
             boolean allowOriginResponse = true;
             if (!isSameOrigin_) {

--- a/src/main/java/org/htmlunit/util/EncodingSniffer.java
+++ b/src/main/java/org/htmlunit/util/EncodingSniffer.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_16BE;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -469,6 +470,7 @@ public final class EncodingSniffer {
      *         or {@code null} if the encoding could not be determined
      * @throws IOException if an IO error occurs
      */
+    @Deprecated
     public static Charset sniffEncoding(final List<NameValuePair> headers, final InputStream content)
         throws IOException {
         final Charset charset;
@@ -493,6 +495,7 @@ public final class EncodingSniffer {
      * @param headers the HTTP response headers
      * @return {@code true} if the specified HTTP response headers indicate an HTML response
      */
+    @Deprecated
     static boolean isHtml(final List<NameValuePair> headers) {
         return contentTypeEndsWith(headers, MimeType.TEXT_HTML);
     }
@@ -503,6 +506,7 @@ public final class EncodingSniffer {
      * @param headers the HTTP response headers
      * @return {@code true} if the specified HTTP response headers indicate an XML response
      */
+    @Deprecated
     static boolean isXml(final List<NameValuePair> headers) {
         return contentTypeEndsWith(headers, MimeType.TEXT_XML, MimeType.APPLICATION_XML, "text/vnd.wap.wml", "+xml");
     }
@@ -551,6 +555,7 @@ public final class EncodingSniffer {
      *         or {@code null} if the encoding could not be determined
      * @throws IOException if an IO error occurs
      */
+    @Deprecated
     public static Charset sniffHtmlEncoding(final List<NameValuePair> headers, final InputStream content)
         throws IOException {
 
@@ -583,6 +588,7 @@ public final class EncodingSniffer {
      *         or {@code null} if the encoding could not be determined
      * @throws IOException if an IO error occurs
      */
+    @Deprecated
     public static Charset sniffXmlEncoding(final List<NameValuePair> headers, final InputStream content)
         throws IOException {
 
@@ -602,6 +608,7 @@ public final class EncodingSniffer {
         return encoding;
     }
 
+    @Deprecated
     private static Charset sniffCssEncoding(final List<NameValuePair> headers, final InputStream content)
         throws IOException {
 
@@ -635,6 +642,7 @@ public final class EncodingSniffer {
      *         or {@code null} if the encoding could not be determined
      * @throws IOException if an IO error occurs
      */
+    @Deprecated
     public static Charset sniffUnknownContentTypeEncoding(final List<NameValuePair> headers, final InputStream content)
         throws IOException {
 
@@ -658,6 +666,7 @@ public final class EncodingSniffer {
      * @return the encoding sniffed from the specified HTTP headers, or {@code null} if the encoding
      *         could not be determined
      */
+    @Deprecated
     public static Charset sniffEncodingFromHttpHeaders(final List<NameValuePair> headers) {
         for (final NameValuePair pair : headers) {
             final String name = pair.getName();
@@ -723,7 +732,20 @@ public final class EncodingSniffer {
      * @return the encoding sniffed from the specified bytes, or {@code null} if the encoding
      *         could not be determined
      */
-    static Charset sniffEncodingFromMetaTag(final byte[] bytes) {
+    @Deprecated
+    static Charset sniffEncodingFromMetaTag(final byte[] bytes)throws IOException {
+        return sniffEncodingFromMetaTag(new ByteArrayInputStream(bytes));
+    }
+
+    /**
+     * Attempts to sniff an encoding from an HTML <code>meta</code> tag in the specified byte array.
+     *
+     * @param is the content stream to check for an HTML <code>meta</code> tag
+     * @return the encoding sniffed from the specified bytes, or {@code null} if the encoding
+     *         could not be determined
+     */
+    public static Charset sniffEncodingFromMetaTag(final InputStream is) throws IOException {
+        final byte[] bytes = read(is, SIZE_OF_HTML_CONTENT_SNIFFED);
         for (int i = 0; i < bytes.length; i++) {
             if (matches(bytes, i, COMMENT_START)) {
                 i = indexOfSubArray(bytes, COMMENT_END, i);
@@ -915,7 +937,7 @@ public final class EncodingSniffer {
      * @return the encoding found in the specified <code>Content-Type</code> value, or {@code null} if no
      *         encoding was found
      */
-    static Charset extractEncodingFromContentType(final String s) {
+    public static Charset extractEncodingFromContentType(final String s) {
         if (s == null) {
             return null;
         }
@@ -986,7 +1008,20 @@ public final class EncodingSniffer {
      * @param bytes the XML content to sniff
      * @return the encoding of the specified XML content, or {@code null} if it could not be determined
      */
-    static Charset sniffEncodingFromXmlDeclaration(final byte[] bytes) {
+    @Deprecated
+    static Charset sniffEncodingFromXmlDeclaration(final byte[] bytes) throws IOException {
+        return sniffEncodingFromXmlDeclaration(new ByteArrayInputStream(bytes));
+    }
+
+    /**
+     * Searches the specified XML content for an XML declaration and returns the encoding if found,
+     * otherwise returns {@code null}.
+     *
+     * @param is the content stream to check for the charset declaration
+     * @return the encoding of the specified XML content, or {@code null} if it could not be determined
+     */
+    public static Charset sniffEncodingFromXmlDeclaration(final InputStream is) throws IOException {
+        final byte[] bytes = read(is, SIZE_OF_XML_CONTENT_SNIFFED);
         Charset encoding = null;
         if (bytes.length > 5
                 && XML_DECLARATION_PREFIX[0] == bytes[0]
@@ -1026,12 +1061,18 @@ public final class EncodingSniffer {
         return encoding;
     }
 
+    @Deprecated
+    static Charset sniffEncodingFromCssDeclaration(final byte[] bytes) throws IOException {
+        return sniffEncodingFromXmlDeclaration(new ByteArrayInputStream(bytes));
+    }
+
     /**
      * Parses and returns the charset declaration at the start of a css file if any, otherwise returns {@code null}.
      *
      * <p>e.g. <pre>@charset "UTF-8"</pre>
      */
-    static Charset sniffEncodingFromCssDeclaration(final byte[] bytes) {
+    public static Charset sniffEncodingFromCssDeclaration(final InputStream is) throws IOException {
+        byte[] bytes = read(is, SIZE_OF_CSS_CONTENT_SNIFFED);
         if (bytes.length < CSS_CHARSET_DECLARATION_PREFIX.length) {
             return null;
         }

--- a/src/main/java/org/htmlunit/util/EncodingSniffer.java
+++ b/src/main/java/org/htmlunit/util/EncodingSniffer.java
@@ -716,9 +716,17 @@ public final class EncodingSniffer {
                         Charset charset = null;
                         if ("charset".equals(name)) {
                             charset = toCharset(value);
+                            // https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding
+                            if (charset == null && value.equals("x-user-defined")) {
+                                charset = Charset.forName("windows-1252");
+                            }
                         }
                         else if ("content".equals(name)) {
                             charset = extractEncodingFromContentType(value);
+                            // https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding
+                            if (charset == null && value.contains("x-user-defined")) {
+                                charset = Charset.forName("windows-1252");
+                            }
                             if (charset == null) {
                                 continue;
                             }

--- a/src/main/java/org/htmlunit/util/EncodingSniffer.java
+++ b/src/main/java/org/htmlunit/util/EncodingSniffer.java
@@ -548,14 +548,14 @@ public final class EncodingSniffer {
     public static Charset sniffHtmlEncoding(final List<NameValuePair> headers, final InputStream content)
         throws IOException {
 
-        Charset encoding = sniffEncodingFromHttpHeaders(headers);
-        if (encoding != null || content == null) {
+        byte[] bytes = read(content, 3);
+        Charset encoding = sniffEncodingFromUnicodeBom(bytes);
+        if (encoding != null) {
             return encoding;
         }
 
-        byte[] bytes = read(content, 3);
-        encoding = sniffEncodingFromUnicodeBom(bytes);
-        if (encoding != null) {
+        encoding = sniffEncodingFromHttpHeaders(headers);
+        if (encoding != null || content == null) {
             return encoding;
         }
 
@@ -580,14 +580,14 @@ public final class EncodingSniffer {
     public static Charset sniffXmlEncoding(final List<NameValuePair> headers, final InputStream content)
         throws IOException {
 
-        Charset encoding = sniffEncodingFromHttpHeaders(headers);
-        if (encoding != null || content == null) {
+        byte[] bytes = read(content, 3);
+        Charset encoding = sniffEncodingFromUnicodeBom(bytes);
+        if (encoding != null) {
             return encoding;
         }
 
-        byte[] bytes = read(content, 3);
-        encoding = sniffEncodingFromUnicodeBom(bytes);
-        if (encoding != null) {
+        encoding = sniffEncodingFromHttpHeaders(headers);
+        if (encoding != null || content == null) {
             return encoding;
         }
 
@@ -613,13 +613,16 @@ public final class EncodingSniffer {
     public static Charset sniffUnknownContentTypeEncoding(final List<NameValuePair> headers, final InputStream content)
         throws IOException {
 
-        Charset encoding = sniffEncodingFromHttpHeaders(headers);
-        if (encoding != null || content == null) {
+        final byte[] bytes = read(content, 3);
+        Charset encoding = sniffEncodingFromUnicodeBom(bytes);
+        if (encoding != null) {
             return encoding;
         }
 
-        final byte[] bytes = read(content, 3);
-        encoding = sniffEncodingFromUnicodeBom(bytes);
+        encoding = sniffEncodingFromHttpHeaders(headers);
+        if (encoding != null || content == null) {
+            return encoding;
+        }
         return encoding;
     }
 

--- a/src/main/java/org/htmlunit/util/EncodingSniffer.java
+++ b/src/main/java/org/htmlunit/util/EncodingSniffer.java
@@ -478,16 +478,6 @@ public final class EncodingSniffer {
         else {
             charset = sniffUnknownContentTypeEncoding(headers, content);
         }
-
-        // this is was browsers do
-        if (charset != null) {
-            if ("US-ASCII".equals(charset.name())) {
-                return Charset.forName("windows-1252");
-            }
-            if ("GB2312".equals(charset.name())) {
-                return Charset.forName("GBK");
-            }
-        }
         return charset;
     }
 
@@ -1007,11 +997,12 @@ public final class EncodingSniffer {
      * @return {@code Charset} if the specified charset name is supported on this platform
      */
     public static Charset toCharset(final String charsetName) {
-        if (StringUtils.isEmpty(charsetName)) {
+        String nameFromLabel = translateEncodingLabel(charsetName);
+        if (nameFromLabel == null) {
             return null;
         }
         try {
-            return Charset.forName(charsetName);
+            return Charset.forName(nameFromLabel);
         }
         catch (final IllegalCharsetNameException | UnsupportedCharsetException e) {
             return null;
@@ -1179,14 +1170,25 @@ public final class EncodingSniffer {
      * @param encodingLabel the label to translate
      * @return the normalized encoding name or null if not found
      */
+    @Deprecated
     public static String translateEncodingLabel(final Charset encodingLabel) {
-        if (null == encodingLabel) {
+        return translateEncodingLabel(encodingLabel.name());
+    }
+
+    /**
+     * Translates the given encoding label into a normalized form
+     * according to <a href="http://encoding.spec.whatwg.org/#encodings">Reference</a>.
+     * @param encodingLabel the label to translate
+     * @return the normalized encoding name or null if not found
+     */
+    public static String translateEncodingLabel(final String encodingLabel) {
+        if (StringUtils.isEmpty(encodingLabel)) {
             return null;
         }
-        final String encLC = encodingLabel.name().toLowerCase(Locale.ROOT);
+        final String encLC = encodingLabel.toLowerCase(Locale.ROOT);
         final String enc = ENCODING_FROM_LABEL.get(encLC);
         if (encLC.equals(enc)) {
-            return encodingLabel.name();
+            return encodingLabel;
         }
         return enc;
     }

--- a/src/main/java/org/htmlunit/util/EncodingSniffer.java
+++ b/src/main/java/org/htmlunit/util/EncodingSniffer.java
@@ -427,9 +427,8 @@ public final class EncodingSniffer {
 
     /**
      * The number of HTML bytes to sniff for encoding info embedded in <code>meta</code> tags;
-     * relatively large because we don't have a fallback.
      */
-    private static final int SIZE_OF_HTML_CONTENT_SNIFFED = 4096;
+    private static final int SIZE_OF_HTML_CONTENT_SNIFFED = 1024;
 
     /**
      * The number of XML bytes to sniff for encoding info embedded in the XML declaration;

--- a/src/main/java/org/htmlunit/util/EncodingSniffer.java
+++ b/src/main/java/org/htmlunit/util/EncodingSniffer.java
@@ -90,7 +90,7 @@ public final class EncodingSniffer {
     private static final byte[] WHITESPACE = {0x09, 0x0A, 0x0C, 0x0D, 0x20, 0x3E};
     private static final byte[] COMMENT_END = {'-', '-', '>'};
 
-    /** <a href="http://encoding.spec.whatwg.org/#encodings">Reference</a> */
+    /** <a href="https://encoding.spec.whatwg.org/#names-and-labels">Encoding names and labels</a> */
     private static final Map<String, String> ENCODING_FROM_LABEL;
     static {
         ENCODING_FROM_LABEL = new HashMap<>();
@@ -98,8 +98,11 @@ public final class EncodingSniffer {
         // The Encoding
         // ------------
         ENCODING_FROM_LABEL.put("unicode-1-1-utf-8", "utf-8");
+        ENCODING_FROM_LABEL.put("unicode11utf8", "utf-8");
+        ENCODING_FROM_LABEL.put("unicode20utf8", "utf-8");
         ENCODING_FROM_LABEL.put("utf-8", "utf-8");
         ENCODING_FROM_LABEL.put("utf8", "utf-8");
+        ENCODING_FROM_LABEL.put("x-unicode20utf8", "utf-8");
 
         // Legacy single-byte encodings
         // ----------------------------
@@ -367,8 +370,9 @@ public final class EncodingSniffer {
         ENCODING_FROM_LABEL.put("csiso2022jp", "iso-2022-jp");
         ENCODING_FROM_LABEL.put("iso-2022-jp", "iso-2022-jp");
 
-        // iso-2022-jp
+        // shift_jis
         ENCODING_FROM_LABEL.put("csshiftjis", "shift_jis");
+        ENCODING_FROM_LABEL.put("ms932", "shift_jis");
         ENCODING_FROM_LABEL.put("ms_kanji", "shift_jis");
         ENCODING_FROM_LABEL.put("shift-jis", "shift_jis");
         ENCODING_FROM_LABEL.put("shift_jis", "shift_jis");
@@ -396,14 +400,22 @@ public final class EncodingSniffer {
 
         // replacement
         ENCODING_FROM_LABEL.put("csiso2022kr", "replacement");
+        ENCODING_FROM_LABEL.put("hz-gb-2312", "replacement");
         ENCODING_FROM_LABEL.put("iso-2022-cn", "replacement");
         ENCODING_FROM_LABEL.put("iso-2022-cn-ext", "replacement");
         ENCODING_FROM_LABEL.put("iso-2022-kr", "replacement");
+        ENCODING_FROM_LABEL.put("replacement", "replacement");
 
         // utf-16be
+        ENCODING_FROM_LABEL.put("unicodefffe", "utf-16be");
         ENCODING_FROM_LABEL.put("utf-16be", "utf-16be");
 
         // utf-16le
+        ENCODING_FROM_LABEL.put("csunicode", "utf-16le");
+        ENCODING_FROM_LABEL.put("iso-10646-ucs-2", "utf-16le");
+        ENCODING_FROM_LABEL.put("ucs-2", "utf-16le");
+        ENCODING_FROM_LABEL.put("unicode", "utf-16le");
+        ENCODING_FROM_LABEL.put("unicodefeff", "utf-16le");
         ENCODING_FROM_LABEL.put("utf-16", "utf-16le");
         ENCODING_FROM_LABEL.put("utf-16le", "utf-16le");
 

--- a/src/main/java/org/htmlunit/util/WebResponseWrapper.java
+++ b/src/main/java/org/htmlunit/util/WebResponseWrapper.java
@@ -98,9 +98,19 @@ public class WebResponseWrapper extends WebResponse {
 
     /**
      * {@inheritDoc}
+     * The default behavior of this method is to return getHeaderContentCharset() on the wrapped webResponse object.
+     */
+    @Override
+    public Charset getHeaderContentCharset() {
+        return wrappedWebResponse_.getHeaderContentCharset();
+    }
+
+    /**
+     * {@inheritDoc}
      * The default behavior of this method is to return getContentCharsetOrNull() on the wrapped webResponse object.
      */
     @Override
+    @Deprecated
     public Charset getContentCharsetOrNull() {
         return wrappedWebResponse_.getContentCharsetOrNull();
     }

--- a/src/main/java/org/htmlunit/util/WebResponseWrapper.java
+++ b/src/main/java/org/htmlunit/util/WebResponseWrapper.java
@@ -190,6 +190,7 @@ public class WebResponseWrapper extends WebResponse {
      * {@inheritDoc}
      * The default behavior of this method is to call defaultCharsetUtf8() on the wrapped webResponse object.
      */
+    @Deprecated
     @Override
     public void defaultCharsetUtf8() {
         wrappedWebResponse_.defaultCharsetUtf8();

--- a/src/test/java/org/htmlunit/WebResponseTest.java
+++ b/src/test/java/org/htmlunit/WebResponseTest.java
@@ -107,7 +107,7 @@ public class WebResponseTest extends WebServerTestCase {
      */
     @Test
     public void illegalCharset() throws Exception {
-        illegalCharset("text/html; text/html; charset=ISO-8859-1;", ISO_8859_1);
+        illegalCharset("text/html; text/html; charset=ISO-8859-1;", Charset.forName("windows-1252"));
         illegalCharset("text/html; charset=UTF-8; charset=UTF-8", UTF_8);
         illegalCharset("text/html; charset=#sda+s", ISO_8859_1);
         illegalCharset("text/html; charset=UnknownCharset", ISO_8859_1);

--- a/src/test/java/org/htmlunit/javascript/host/css/CSSStyleSheet3Test.java
+++ b/src/test/java/org/htmlunit/javascript/host/css/CSSStyleSheet3Test.java
@@ -253,7 +253,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void _ISO88591___() throws Exception {
         charset(TestCharset.ISO88591, null, null, null);
     }
@@ -263,7 +262,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void _ISO88591__UTF8_() throws Exception {
         charset(TestCharset.ISO88591, null, TestCharset.UTF8, null);
     }
@@ -291,7 +289,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void _ISO88591_ISO88591__() throws Exception {
         charset(TestCharset.ISO88591, TestCharset.ISO88591, null, null);
     }
@@ -310,7 +307,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void _ISO88591_ISO88591_UTF8_() throws Exception {
         charset(TestCharset.ISO88591, TestCharset.ISO88591, TestCharset.UTF8, null);
     }
@@ -464,7 +460,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void _UTF8_ISO88591_UTF8_() throws Exception {
         charset(TestCharset.UTF8, TestCharset.ISO88591, TestCharset.UTF8, null);
     }
@@ -474,7 +469,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void _UTF8_ISO88591__() throws Exception {
         charset(TestCharset.UTF8, TestCharset.ISO88591, null, null);
     }
@@ -574,7 +568,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void __ISO88591_UTF8_() throws Exception {
         charset(null, TestCharset.ISO88591, TestCharset.UTF8, null);
     }
@@ -584,7 +577,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void __ISO88591__() throws Exception {
         charset(null, TestCharset.ISO88591, null, null);
     }
@@ -666,7 +658,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void ___UTF8_() throws Exception {
         charset(null, null, TestCharset.UTF8, null);
     }
@@ -676,7 +667,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void ____() throws Exception {
         charset(null, null, null, null);
     }
@@ -713,7 +703,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void _GB2312_ISO88591_UTF8_() throws Exception {
         charset(TestCharset.GB2312, TestCharset.ISO88591, TestCharset.UTF8, null);
     }
@@ -723,7 +712,6 @@ public class CSSStyleSheet3Test extends WebDriverTestCase {
      */
     @Test
     @Alerts({"\"a\"", "\"Ã¤\"", "\"Ø£Ù‡Ù„Ø§Ù‹\"", "\"Ð¼Ð¸Ñ€\"", "\"æˆ¿é—´\""})
-    @NotYetImplemented
     public void _GB2312_ISO88591__() throws Exception {
         charset(TestCharset.GB2312, TestCharset.ISO88591, null, null);
     }

--- a/src/test/java/org/htmlunit/util/EncodingSnifferTest.java
+++ b/src/test/java/org/htmlunit/util/EncodingSnifferTest.java
@@ -15,16 +15,14 @@
 package org.htmlunit.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.singletonList;
 import static org.htmlunit.util.EncodingSniffer.extractEncodingFromContentType;
 import static org.htmlunit.util.EncodingSniffer.sniffEncodingFromCssDeclaration;
-import static org.htmlunit.util.EncodingSniffer.sniffEncodingFromHttpHeaders;
 import static org.htmlunit.util.EncodingSniffer.sniffEncodingFromMetaTag;
 import static org.htmlunit.util.EncodingSniffer.sniffEncodingFromXmlDeclaration;
 import static org.junit.Assert.assertSame;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import org.htmlunit.HttpHeader;
 import org.junit.Test;
@@ -52,7 +50,7 @@ public class EncodingSnifferTest {
 
     private static void header(final Charset expectedEncoding, final String headerName, final String headerValue) {
         final NameValuePair header = new NameValuePair(headerName, headerValue);
-        assertSame(expectedEncoding, sniffEncodingFromHttpHeaders(singletonList(header)));
+        assertSame(expectedEncoding, extractEncodingFromContentType(header.getValue()));
     }
 
     /**
@@ -83,8 +81,8 @@ public class EncodingSnifferTest {
         meta(UTF_8, "abc <meta http-equiv='Content-Type' content='text/html; chArsEt=UtF-8'/>");
     }
 
-    private static void meta(final Charset expectedEncoding, final String content) {
-        assertSame(expectedEncoding, sniffEncodingFromMetaTag(content.getBytes()));
+    private static void meta(final Charset expectedEncoding, final String content) throws Exception {
+        assertSame(expectedEncoding, sniffEncodingFromMetaTag(new ByteArrayInputStream(content.getBytes())));
     }
 
     /**
@@ -108,8 +106,8 @@ public class EncodingSnifferTest {
         xmlDeclaration(UTF_8, "<?xml encoding=\"utf-8\"?>");
     }
 
-    private static void xmlDeclaration(final Charset expectedEncoding, final String content) {
-        assertSame(expectedEncoding, sniffEncodingFromXmlDeclaration(content.getBytes()));
+    private static void xmlDeclaration(final Charset expectedEncoding, final String content) throws Exception {
+        assertSame(expectedEncoding, sniffEncodingFromXmlDeclaration(new ByteArrayInputStream(content.getBytes())));
     }
 
     /**
@@ -128,8 +126,8 @@ public class EncodingSnifferTest {
         cssDeclaration(null, " @charset \"utf-8\";");
         cssDeclaration(null, "@charset \"blah\";");}
 
-    private static void cssDeclaration(final Charset expectedEncoding, final String content) {
-        assertSame(expectedEncoding, sniffEncodingFromCssDeclaration(content.getBytes()));
+    private static void cssDeclaration(final Charset expectedEncoding, final String content) throws Exception {
+        assertSame(expectedEncoding, sniffEncodingFromCssDeclaration(new ByteArrayInputStream(content.getBytes())));
     }
 
     /**

--- a/src/test/java/org/htmlunit/util/EncodingSnifferTest.java
+++ b/src/test/java/org/htmlunit/util/EncodingSnifferTest.java
@@ -17,12 +17,14 @@ package org.htmlunit.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.htmlunit.util.EncodingSniffer.extractEncodingFromContentType;
+import static org.htmlunit.util.EncodingSniffer.sniffEncodingFromCssDeclaration;
 import static org.htmlunit.util.EncodingSniffer.sniffEncodingFromHttpHeaders;
 import static org.htmlunit.util.EncodingSniffer.sniffEncodingFromMetaTag;
 import static org.htmlunit.util.EncodingSniffer.sniffEncodingFromXmlDeclaration;
 import static org.junit.Assert.assertSame;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.htmlunit.HttpHeader;
 import org.junit.Test;
@@ -108,6 +110,26 @@ public class EncodingSnifferTest {
 
     private static void xmlDeclaration(final Charset expectedEncoding, final String content) {
         assertSame(expectedEncoding, sniffEncodingFromXmlDeclaration(content.getBytes()));
+    }
+
+    /**
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void fromCssDeclaration() throws Exception {
+        cssDeclaration(null, "");
+        cssDeclaration(null, "foo");
+        cssDeclaration(null, "@charset");
+        cssDeclaration(null, "@charset \"utf-8");
+        cssDeclaration(null, "@charset \"utf-8\"");
+        cssDeclaration(null, "@charset\"utf-8\";");
+        cssDeclaration(null, "@charset 'utf-8';");
+        cssDeclaration(UTF_8, "@charset \"utf-8\";");
+        cssDeclaration(null, " @charset \"utf-8\";");
+        cssDeclaration(null, "@charset \"blah\";");}
+
+    private static void cssDeclaration(final Charset expectedEncoding, final String content) {
+        assertSame(expectedEncoding, sniffEncodingFromCssDeclaration(content.getBytes()));
     }
 
     /**


### PR DESCRIPTION
### This PR does the following

- Add some missing [encoding labels conversions](https://encoding.spec.whatwg.org/#names-and-labels) and also do label conversions inside `EncodingSniffer.toCharset()`.

- Fixes the priority of the BOM by moving it to the highest priority charset to be in line with [html](https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding)/[xml](https://www.rfc-editor.org/rfc/rfc7303.html#section-3.2)/[js](https://www.rfc-editor.org/rfc/rfc9239#section-4.2)/[css](https://www.w3.org/TR/css-syntax-3/#input-byte-stream) etc. specifications.
- Add `WebRequest.defaultResponseContentCharset_` that can be used to set the charset for the `WebResponse` when no charset could be found. Also deprecates `WebResponse.defaultUtf8()`.
- Update the default charset of [css](https://www.w3.org/TR/css-syntax-3/#input-byte-stream)/[js](https://www.rfc-editor.org/rfc/rfc9239#section-4.2) to `UTF-8`.
- Fix `<iframe>` so that the parent charset is used when no charset could otherwise be found.
- Change the fallback charset of `WebResponse` from `ISO-8859-1` to `UTF-8` to be in line with the latest [standards](https://datatracker.ietf.org/doc/html/rfc6838#section-4.2.1).
- Change the number of prescan bytes of an HTML document from `4096` to `1024` bytes to be in line with [specs](https://html.spec.whatwg.org/multipage/semantics.html#charset1024).
- Treat `x-user-defined` charset declaration in meta tag as `windows-1252` as documented in [specs](https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding).
- Add support for CSS `@charset` declaration.
- Change `WebResponse.getContentCharset()` so that it "just works" for most cases.
   - Move the BOM and content-type header charset reading code from `EncodingSniffer` to `WebResponse` so that `WebResponse` has first-hand knowledge of these concepts.
  - Deprecate the hard to understand `getContentCharsetOrNull()` and instead add `wasContentCharsetTentative()` used to check if the charset returned by `getContentCharset()` was "[tenatative](https://html.spec.whatwg.org/multipage/parsing.html#concept-encoding-confidence)".
  - Add method `WebResponse.getHeaderContentCharset()` to cover the limited use-case that `getContentCharsetOrNull()` sort of handled.