### PR TITLE
Add missing implementations for RadioNodeList and HTMLFormControlsCollection

### DIFF
--- a/src/main/java/org/htmlunit/javascript/host/dom/RadioNodeList.java
+++ b/src/main/java/org/htmlunit/javascript/host/dom/RadioNodeList.java
@@ -14,17 +14,40 @@
  */
 package org.htmlunit.javascript.host.dom;
 
+import static org.htmlunit.html.DomElement.ATTRIBUTE_NOT_DEFINED;
+
+import java.util.List;
+
+import org.htmlunit.html.DomNode;
+import org.htmlunit.html.HtmlRadioButtonInput;
 import org.htmlunit.javascript.configuration.JsxClass;
 import org.htmlunit.javascript.configuration.JsxConstructor;
+import org.htmlunit.javascript.configuration.JsxGetter;
+import org.htmlunit.javascript.configuration.JsxSetter;
 
 /**
  * A JavaScript object for {@code RadioNodeList}.
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
 @JsxClass
 public class RadioNodeList extends NodeList {
+
+    /**
+     * Creates an instance.
+     */
+    public RadioNodeList() {
+    }
+
+    public RadioNodeList(final DomNode domNode) {
+        super(domNode, true);
+    }
+
+    public RadioNodeList(final DomNode domNode, final List<DomNode> initialElements) {
+        super(domNode, initialElements);
+    }
 
     /**
      * JavaScript constructor.
@@ -33,5 +56,39 @@ public class RadioNodeList extends NodeList {
     @JsxConstructor
     public void jsConstructor() {
         super.jsConstructor();
+    }
+
+    /**
+     * @see <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#the-htmlformcontrolscollection-interface">HTML Standard</a>
+     */
+    @JsxGetter
+    public String getValue() {
+        for (DomNode node : getElements()) {
+            if (node instanceof HtmlRadioButtonInput && ((HtmlRadioButtonInput) node).isChecked()) {
+                String value = ((HtmlRadioButtonInput)node).getValueAttribute();
+                return value == ATTRIBUTE_NOT_DEFINED ? "on" : value;
+            }
+        }
+
+        return "";
+    }
+
+    /**
+     * @see <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#the-htmlformcontrolscollection-interface">HTML Standard</a>
+     */
+    @JsxSetter
+    public void setValue(final String newValue) {
+        for (DomNode node : getElements()) {
+            if (node instanceof HtmlRadioButtonInput) {
+                String value = ((HtmlRadioButtonInput)node).getValueAttribute();
+                if (value == ATTRIBUTE_NOT_DEFINED) {
+                    value = "on";
+                }
+                if (newValue.equals(value)) {
+                    ((HtmlRadioButtonInput)node).setChecked(true);
+                    break;
+                }
+            }
+        }
     }
 }

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLFormControlsCollection.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLFormControlsCollection.java
@@ -14,17 +14,39 @@
  */
 package org.htmlunit.javascript.host.html;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.htmlunit.html.DomElement;
+import org.htmlunit.html.DomNode;
 import org.htmlunit.javascript.configuration.JsxClass;
 import org.htmlunit.javascript.configuration.JsxConstructor;
+import org.htmlunit.javascript.configuration.JsxFunction;
+import org.htmlunit.javascript.host.dom.RadioNodeList;
 
 /**
  * A JavaScript object for {@code HTMLFormControlsCollection}.
  *
  * @author Ahmed Ashour
  * @author Ronald Brill
+ * @author Lai Quang Duong
  */
 @JsxClass
 public class HTMLFormControlsCollection extends HTMLCollection {
+
+    /**
+     * Creates an instance.
+     */
+    public HTMLFormControlsCollection() {
+    }
+
+    public HTMLFormControlsCollection(final DomNode domNode, final boolean attributeChangeSensitive) {
+        super(domNode, attributeChangeSensitive);
+    }
+
+    HTMLFormControlsCollection(final DomNode domNode, final List<DomNode> initialElements) {
+        super(domNode, initialElements);
+    }
 
     /**
      * JavaScript constructor.
@@ -33,5 +55,44 @@ public class HTMLFormControlsCollection extends HTMLCollection {
     @JsxConstructor
     public void jsConstructor() {
         super.jsConstructor();
+    }
+
+    /**
+     * @see <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#the-htmlformcontrolscollection-interface">HTML Standard</a>
+     */
+    @Override
+    @JsxFunction
+    public Object namedItem(final String name) {
+        if (name.isEmpty()) {
+            return null;
+        }
+
+        List<DomNode> elements = new ArrayList<>();
+        for (final Object next : getElements()) {
+            if (next instanceof DomElement) {
+                final DomElement elem = (DomElement) next;
+                final String nodeName = elem.getAttributeDirect(DomElement.NAME_ATTRIBUTE);
+                if (name.equals(nodeName)) {
+                    elements.add(elem);
+                    continue;
+                }
+
+                final String id = elem.getId();
+                if (name.equals(id)) {
+                    elements.add(elem);
+                }
+            }
+        }
+
+        if (elements.isEmpty()) {
+            return null;
+        }
+        if (elements.size() == 1) {
+            return getScriptableForElement(elements.get(0));
+        }
+
+        RadioNodeList nodeList = new RadioNodeList(getDomNodeOrDie(), elements);
+        nodeList.setElementsSupplier(getElementSupplier());
+        return nodeList;
     }
 }

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLFormElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLFormElement.java
@@ -103,10 +103,10 @@ public class HTMLFormElement extends HTMLElement implements Function {
      * @return the value of this property
      */
     @JsxGetter
-    public HTMLCollection getElements() {
+    public HTMLFormControlsCollection getElements() {
         final HtmlForm htmlForm = getHtmlForm();
 
-        final HTMLCollection elements = new HTMLCollection(htmlForm, false) {
+        final HTMLFormControlsCollection elements = new HTMLFormControlsCollection(htmlForm, false) {
             @Override
             protected Object getWithPreemption(final String name) {
                 return HTMLFormElement.this.getWithPreemption(name);

--- a/src/main/java/org/htmlunit/javascript/host/html/HTMLFormElement.java
+++ b/src/main/java/org/htmlunit/javascript/host/html/HTMLFormElement.java
@@ -46,6 +46,7 @@ import org.htmlunit.javascript.configuration.JsxSetter;
 import org.htmlunit.javascript.configuration.JsxSymbol;
 import org.htmlunit.javascript.host.dom.AbstractList.EffectOnCache;
 import org.htmlunit.javascript.host.dom.DOMTokenList;
+import org.htmlunit.javascript.host.dom.RadioNodeList;
 import org.htmlunit.javascript.host.event.Event;
 import org.htmlunit.util.MimeType;
 
@@ -61,6 +62,7 @@ import org.htmlunit.util.MimeType;
  * @author Sudhan Moghe
  * @author Ronald Brill
  * @author Frank Danek
+ * @author Lai Quang Duong
  *
  * @see <a href="http://msdn.microsoft.com/en-us/library/ms535249.aspx">MSDN documentation</a>
  */
@@ -382,9 +384,9 @@ public class HTMLFormElement extends HTMLElement implements Function {
         }
         final List<DomNode> nodes = new ArrayList<>(elements);
 
-        final HTMLCollection coll = new HTMLCollection(getHtmlForm(), nodes);
-        coll.setElementsSupplier((Supplier<List<DomNode>> & Serializable) () -> new ArrayList<>(findElements(name)));
-        return coll;
+        final RadioNodeList nodeList = new RadioNodeList(getHtmlForm(), nodes);
+        nodeList.setElementsSupplier((Supplier<List<DomNode>> & Serializable) () -> new ArrayList<>(findElements(name)));
+        return nodeList;
     }
 
     /**

--- a/src/test/java/org/htmlunit/javascript/host/dom/RadioNodeListTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/dom/RadioNodeListTest.java
@@ -35,7 +35,7 @@ public class RadioNodeListTest extends WebDriverTestCase {
      * @throws Exception on test failure
      */
     @Test
-    @Alerts({"false", "false", "false"}) // FIXME: should be "true", "true", "true"
+    @Alerts({"true", "true", "true"})
     public void instanceOf() throws Exception {
         final String html = "<html><head>\n"
                 + "<script>\n"
@@ -57,7 +57,7 @@ public class RadioNodeListTest extends WebDriverTestCase {
      * @throws Exception on test failure
      */
     @Test
-    @Alerts({"undefined", "1", "1", "undefined", "undefined"}) //FIXME: should be "2", "1", "1", "", "on"
+    @Alerts({"2", "1", "1", "", "on"})
     public void getValue() throws Exception {
         final String html = "<html><head>\n"
                 + "<script>\n"
@@ -81,7 +81,7 @@ public class RadioNodeListTest extends WebDriverTestCase {
      * @throws Exception on test failure
      */
     @Test
-    @Alerts({"undefined", "on", "false"}) // FIXME: should be "2", "on", "true"
+    @Alerts({"2", "on", "true"})
     public void setValue() throws Exception {
         final String html = "<html><head>\n"
                 + "<script>\n"

--- a/src/test/java/org/htmlunit/javascript/host/dom/RadioNodeListTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/dom/RadioNodeListTest.java
@@ -1,0 +1,102 @@
+package org.htmlunit.javascript.host.dom;
+
+import org.htmlunit.WebDriverTestCase;
+import org.htmlunit.junit.BrowserRunner;
+import org.htmlunit.junit.BrowserRunner.Alerts;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for {@link RadioNodeList}.
+ *
+ * @author Lai Quang Duong
+ */
+@RunWith(BrowserRunner.class)
+public class RadioNodeListTest extends WebDriverTestCase {
+
+    private static final String FORM_HTML = "<form name='form'>\n"
+            + "<input type='text' name='first' value='0'/>\n"
+            + "<input type='radio' name='first'/>\n"
+            + "<input type='radio' name='first' value='2' checked/>\n"
+            + "<input type='radio' name='first' value='3'/>\n"
+            + "\n"
+            + "<input type='radio' name='second' value='1'/>\n"
+            + "\n"
+            + "<input type='radio' name='third' value='1' checked/>\n"
+            + "\n"
+            + "<input type='radio' name='fourth' value='1'/>\n"
+            + "<input type='radio' name='fourth' value='2'/>\n"
+            + "\n"
+            + "<input type='radio' name='fifth' value='1'/>\n"
+            + "<input type='radio' name='fifth' checked/>\n"
+            + "</form>";
+
+    /**
+     * @throws Exception on test failure
+     */
+    @Test
+    @Alerts({"false", "false", "false"}) // FIXME: should be "true", "true", "true"
+    public void instanceOf() throws Exception {
+        final String html = "<html><head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log(document.form.first instanceof RadioNodeList);\n"
+                + "    log(document.form.fourth instanceof RadioNodeList);\n"
+                + "    log(document.form.fifth instanceof RadioNodeList);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head><body onload='test()'>\n"
+                + FORM_HTML
+                + "</body></html>\n";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception on test failure
+     */
+    @Test
+    @Alerts({"undefined", "1", "1", "undefined", "undefined"}) //FIXME: should be "2", "1", "1", "", "on"
+    public void getValue() throws Exception {
+        final String html = "<html><head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log(document.form.first.value);\n"
+                + "    log(document.form.second.value);\n"
+                + "    log(document.form.third.value);\n"
+                + "    log(document.form.fourth.value);\n"
+                + "    log(document.form.fifth.value);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head><body onload='test()'>\n"
+                + FORM_HTML
+                + "</body></html>\n";
+
+        loadPageVerifyTitle2(html);
+    }
+
+    /**
+     * @throws Exception on test failure
+     */
+    @Test
+    @Alerts({"undefined", "on", "false"}) // FIXME: should be "2", "on", "true"
+    public void setValue() throws Exception {
+        final String html = "<html><head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    log(document.form.first.value);\n"
+                + "    document.form.first.value = 'on';\n"
+                + "    log(document.form.first[1].value);\n"
+                + "    log(document.form.first[1].checked);\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head><body onload='test()'>\n"
+                + FORM_HTML
+                + "</body></html>\n";
+
+        loadPageVerifyTitle2(html);
+    }
+}

--- a/src/test/java/org/htmlunit/javascript/host/html/HTMLFormControlsCollectionTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/html/HTMLFormControlsCollectionTest.java
@@ -1,0 +1,52 @@
+package org.htmlunit.javascript.host.html;
+
+import org.htmlunit.WebDriverTestCase;
+import org.htmlunit.junit.BrowserRunner;
+import org.htmlunit.junit.BrowserRunner.Alerts;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for {@link HTMLFormControlsCollection}.
+ *
+ * @author Lai Quang Duong
+ */
+@RunWith(BrowserRunner.class)
+public class HTMLFormControlsCollectionTest extends WebDriverTestCase {
+
+    /**
+     * @throws Exception on test failure
+     */
+    @Test
+    @Alerts({"false", "false", "0", "true", "1", "null"}) //FIXME: should be "true", "true", "2", "true", "1", "null"
+    public void namedItem() throws Exception {
+        final String html = "<html><head>\n"
+                + "<script>\n"
+                + LOG_TITLE_FUNCTION
+                + "  function test() {\n"
+                + "    var elements = document.form.elements;\n"
+                + "\n"
+                + "    log(elements instanceof HTMLFormControlsCollection);\n"
+                + "    log(elements.namedItem('first') instanceof RadioNodeList);\n"
+                + "    log(elements.namedItem('first').value);\n"
+                + "\n"
+                + "    log(elements.namedItem('second') instanceof HTMLInputElement);\n"
+                + "    log(elements.namedItem('second').value);\n"
+                + "\n"
+                + "    log(elements.namedItem('third'));\n"
+                + "  }\n"
+                + "</script>\n"
+                + "</head><body onload='test()'>\n"
+                + "<form name='form'>\n"
+                + "<input type='text' name='first' value='0'/>\n"
+                + "<input type='radio' name='first'/>\n"
+                + "<input type='radio' name='first' value='2' checked/>\n"
+                + "<input type='radio' name='first' value='3'/>\n"
+                + "\n"
+                + "<input type='radio' name='second' value='1'/>\n"
+                + "</form>"
+                + "</body></html>\n";
+
+        loadPageVerifyTitle2(html);
+    }
+}

--- a/src/test/java/org/htmlunit/javascript/host/html/HTMLFormControlsCollectionTest.java
+++ b/src/test/java/org/htmlunit/javascript/host/html/HTMLFormControlsCollectionTest.java
@@ -18,7 +18,7 @@ public class HTMLFormControlsCollectionTest extends WebDriverTestCase {
      * @throws Exception on test failure
      */
     @Test
-    @Alerts({"false", "false", "0", "true", "1", "null"}) //FIXME: should be "true", "true", "2", "true", "1", "null"
+    @Alerts({"true", "true", "2", "true", "1", "null"})
     public void namedItem() throws Exception {
         final String html = "<html><head>\n"
                 + "<script>\n"


### PR DESCRIPTION
### This PR does the following
- Implement [`RadioNodeList.value`](https://developer.mozilla.org/en-US/docs/Web/API/RadioNodeList/value) and [`HtmlFormControlsCollection.namedItem()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormControlsCollection/namedItem) based on [HTML Standards](https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#the-htmlformcontrolscollection-interface)